### PR TITLE
refactor: enhance AppSidebar tooltips & refine MobileNav layout/styles

### DIFF
--- a/components/pos/app-sidebar.tsx
+++ b/components/pos/app-sidebar.tsx
@@ -32,6 +32,11 @@ import {
   SidebarSeparator,
   SidebarTrigger,
 } from "@/components/ui/sidebar"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { sidebarItems } from "@/components/pos/mock-data"
 
 export function AppSidebar() {
@@ -102,24 +107,28 @@ export function AppSidebar() {
       <SidebarFooter>
         <div className="space-y-2 group-data-[collapsible=icon]:hidden">
           <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  className="h-11 w-full justify-start px-2"
-                  title="Account & settings"
-                  aria-label="Open account menu"
-                />
-              }
-            >
-              <Avatar size="sm">
-                <AvatarFallback>KC</AvatarFallback>
-              </Avatar>
-              <div className="flex min-w-0 flex-col text-left">
-                <span className="truncate text-sm font-medium">Kurt</span>
-                <span className="text-muted-foreground truncate text-xs">Store Admin</span>
-              </div>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger render={<span className="block w-full" />}>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      className="h-11 w-full justify-start px-2"
+                      aria-label="Open account menu"
+                    />
+                  }
+                >
+                  <Avatar size="sm">
+                    <AvatarFallback>KC</AvatarFallback>
+                  </Avatar>
+                  <div className="flex min-w-0 flex-col text-left">
+                    <span className="truncate text-sm font-medium">Kurt</span>
+                    <span className="text-muted-foreground truncate text-xs">Store Admin</span>
+                  </div>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="top">Account &amp; settings</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent align="end" className="w-52 !shadow-xs">
               <DropdownMenuGroup>
                 <DropdownMenuLabel>My Account</DropdownMenuLabel>
@@ -161,20 +170,24 @@ export function AppSidebar() {
 
         <div className="hidden group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
           <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button
-                  variant="ghost"
-                  className="size-12 rounded-xl p-0"
-                  title="Account & settings"
-                  aria-label="Open account menu"
-                />
-              }
-            >
-              <Avatar>
-                <AvatarFallback>KC</AvatarFallback>
-              </Avatar>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger render={<span className="inline-flex" />}>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      className="size-12 rounded-xl p-0"
+                      aria-label="Open account menu"
+                    />
+                  }
+                >
+                  <Avatar>
+                    <AvatarFallback>KC</AvatarFallback>
+                  </Avatar>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="right">Account &amp; settings</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent align="end" className="w-52 !shadow-xs">
               <DropdownMenuGroup>
                 <DropdownMenuLabel>My Account</DropdownMenuLabel>

--- a/components/pos/mobile-nav.tsx
+++ b/components/pos/mobile-nav.tsx
@@ -50,12 +50,12 @@ export function MobileNav() {
     { title: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
     { title: "POS", href: "/pos", icon: ShoppingCart },
     { title: "Orders", href: "/orders", icon: Receipt },
-    { title: "Products", href: "/products", icon: Package },
     { title: "More", icon: Ellipsis, kind: "more" },
   ]
 
   // Everything else lives in the "More" sheet.
   const moreItems: NavItem[] = [
+    { title: "Products", href: "/products", icon: Package },
     { title: "Analytics", href: "/analytics", icon: ChartBar },
   ]
 
@@ -85,37 +85,22 @@ export function MobileNav() {
           "pb-[calc(env(safe-area-inset-bottom)+12px)]"
         )}
       >
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background/70 to-transparent" />
-
         <div className="mx-auto w-full max-w-md px-3">
           <div
             className={cn(
               "relative isolate pointer-events-auto",
               "supports-backdrop-filter:backdrop-blur-2xl backdrop-blur-2xl",
-              "bg-background/55 dark:bg-background/35",
+              "bg-background/60 dark:bg-background/30",
+              "saturate-150",
+              "shadow-sm",
+              "rounded-2xl",
               "border border-border/50",
-              "shadow-[0_20px_55px_-28px_rgba(0,0,0,0.45)]",
-              "rounded-[28px]"
+              // Liquid-glass edge treatment (no gradients)
+              "ring-1 ring-white/12 dark:ring-white/10",
+              "after:pointer-events-none after:absolute after:inset-0 after:rounded-2xl after:ring-1 after:ring-black/5 dark:after:ring-white/6"
             )}
           >
-            {/* Liquid highlight */}
-            <div
-              aria-hidden="true"
-              className={cn(
-                "pointer-events-none absolute inset-0 rounded-[28px]",
-                "bg-gradient-to-b from-white/30 via-white/10 to-white/0",
-                "dark:from-white/14 dark:via-white/6"
-              )}
-            />
-            <div
-              aria-hidden="true"
-              className={cn(
-                "pointer-events-none absolute -inset-px rounded-[29px]",
-                "ring-1 ring-white/15 dark:ring-white/10"
-              )}
-            />
-
-            <ul className="relative grid grid-cols-5 px-2 py-2">
+            <ul className="relative grid grid-cols-4 gap-2 px-3 py-2">
               {primary.map((item) => {
                 const active =
                   item.kind === "more"
@@ -139,7 +124,7 @@ export function MobileNav() {
                       }}
                       className={cn(
                         "group relative flex w-full max-w-[86px] flex-col items-center justify-center",
-                        "rounded-2xl px-2 py-2",
+                        "rounded-2xl p-2.5",
                         "transition duration-200",
                         "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
                         "active:scale-[0.98]"
@@ -149,7 +134,7 @@ export function MobileNav() {
                       <span
                         aria-hidden="true"
                         className={cn(
-                          "absolute inset-x-1 top-1 bottom-1 rounded-2xl",
+                          "absolute inset-0 rounded-2xl",
                           "transition duration-200",
                           active
                             ? "bg-foreground/8 dark:bg-foreground/12"


### PR DESCRIPTION
## Description
Added concise tooltips to the account menu in the POS sidebar and refactored the mobile navigation for improved visual treatment and layout. These are non-functional UI improvements aimed at better discoverability and a cleaner, more polished mobile nav appearance.

## Related Issue
N/A

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)  
- [ ] ✨ New feature (non-breaking change that adds functionality)  
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] 📝 Documentation update  
- [x] 🎨 Style/UI update  
- [x] ♻️ Refactor (no functional changes)  
- [ ] 🧪 Test update  
- [ ] 🔧 Configuration change

## Changes Made
- Added `Tooltip`, `TooltipTrigger`, and `TooltipContent` and wrapped the account `DropdownMenuTrigger` in app-sidebar.tsx to show "Account & settings" in both expanded and collapsed sidebar states; removed redundant `title` attributes and ensured `aria-label` remains.
- Reworked mobile-nav.tsx:
  - Moved **Products** into the "More" sheet to declutter the primary nav.
  - Updated container visual treatment: replaced heavy gradients with a subtle "liquid-glass" look (adjusted bg opacity, saturation, shadow, rounding, and ring styles).
  - Simplified overlays (removed gradient highlight overlays) and adjusted grid from 5 → 4 columns with spacing/gap tweaks.
  - Tightened item padding/spacing and adjusted active background positioning for improved touch and visual balance.
- Minor accessibility and semantics cleanup (use of `aria-label`, improved tooltip text).

## Screenshots/Recordings
> I will add the screenshot(s) you provide here.

### Before:
<img width="484" height="1079" alt="image" src="https://github.com/user-attachments/assets/7c6981c4-ad3a-4e34-93ee-67f60ac08f3b" />

### After: 
<img width="456" height="963" alt="image" src="https://github.com/user-attachments/assets/f65b620a-221f-4bda-a516-56dd41008741" />

<img width="458" height="965" alt="image" src="https://github.com/user-attachments/assets/d0536af7-49cc-46db-9314-0c508bb7c3e9" />

## Testing
- [x] I have tested this locally (verified tooltips appear on hover/focus and dropdowns still open; MobileNav shows four primary items with **Products** in More sheet).
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

Short reproduction steps:
1. Run the app and open the POS layout.
2. Hover/focus the account area in the sidebar (expanded and collapsed) — tooltip should appear and the menu should still open.
3. Inspect MobileNav on a narrow viewport — primary nav shows 4 items and **Products** is available via the "More" sheet; verify visual treatment and interactions.

## Checklist
- [x] My code follows the project's coding standards  
- [x] I have performed a self-review of my code  
- [x] I have commented my code where necessary  
- [ ] I have updated the documentation accordingly  
- [x] My changes generate no new warnings or errors  
- [x] I have checked for accessibility compliance  
- [x] I have verified responsive design (if applicable)

## Additional Notes
- These changes are visual/refactor-only and should not impact business logic.  